### PR TITLE
bedrock Agent - Import missing interface

### DIFF
--- a/moya/agents/bedrock_agent.py
+++ b/moya/agents/bedrock_agent.py
@@ -10,7 +10,7 @@ pulling AWS credentials from environment or AWS configuration.
 import json
 import boto3
 from typing import Any, Dict, Optional
-from moya.agents.base_agent import Agent
+from moya.agents.base_agent import Agent, AgentConfig
 from dataclasses import dataclass
 
 @dataclass


### PR DESCRIPTION
The Interface `AgentConfig` is missing in the import.
This leads to an error when the bedrock example code is run.
Fix:
- Import `AgentConfig` from `moya.agents.base_agent` in `bedrock_agent.py` (F988be05L10R10).