### PR TITLE
Fix agent crashing if LLM makes an invalid tool call

### DIFF
--- a/moya/agents/openai_agent.py
+++ b/moya/agents/openai_agent.py
@@ -257,5 +257,7 @@ class OpenAIAgent(Agent):
                 return result
             except TypeError:
                 return f"[Tool '{name}' requires arguments: {tool.parameters}]"
+            except Exception as e:
+                return f"[Error executing tool '{name}': {str(e)}]"
 
         return f"[Tool '{name}' not found]"

--- a/moya/agents/openai_agent.py
+++ b/moya/agents/openai_agent.py
@@ -252,7 +252,10 @@ class OpenAIAgent(Agent):
 
         tool = self.tool_registry.get_tool(name)
         if tool:
-            result = tool.function(**args)
-            return result
+            try:
+                result = tool.function(**args)
+                return result
+            except TypeError:
+                return f"[Tool '{name}' requires arguments: {tool.parameters}]"
 
         return f"[Tool '{name}' not found]"


### PR DESCRIPTION
If the LLM makes a tool call with less than required arguments or invalid arguments the agent would raise a TypeError and crash. This fixes the issue and makes it more robust against invalid tool invocations from an agent.